### PR TITLE
fix error caused by a space in the comment

### DIFF
--- a/ipconflict/subnet.py
+++ b/ipconflict/subnet.py
@@ -19,7 +19,7 @@ def get_ip_set(subnet):
 
 def parse_subnet_data(data):
     subnets = []
-    lines = data.split()
+    lines = data.split('\n')
     for line in lines:
         line = line.strip()
         if not line or not line.startswith('#'):


### PR DESCRIPTION
# what

This PR proposes a fix for the situation when:
- `ipconflict` reads subnet information from a file
- the subnet file has a comment
- the comment has a space

`ipconflict` incorrectly reports the following error in this situation:  `error: invalid subnet format comment`


# why

We'd like to be able to keep comments in the subnet file

# notes

The following `subnets` file cause problems

    # my_comment
    10.168.0.0/20
    10.146.0.0/20

    #my comment
    10.168.0.0/20
    10.146.0.0/20

    # my comment
    10.168.0.0/20
    10.146.0.0/20

The following `subnets` file is fine:

    #my_comment
    10.168.0.0/20
    10.146.0.0/20

The problem is caused by the `split` function, which treats the space as a separator, so `#my comment` becomes the following list `[ '#my', 'comment' ]` after split.
